### PR TITLE
Correct source in podspec

### DIFF
--- a/LifetimeTracker.podspec
+++ b/LifetimeTracker.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author             = { "Krzysztof Zablocki" => "krzysztof.zablocki@pixle.pl" }
   s.social_media_url   = "http://twitter.com/merowing_"
   s.ios.deployment_target = "8.0"
-  s.source       = { :git => ".git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/krzysztofzablocki/LifetimeTracker.git", :tag => s.version.to_s }
   s.source_files  = "Sources/**/*.swift"
   s.resources     = "Sources/**/*.xib"
   s.frameworks  = ["Foundation", "UIKit"]


### PR DESCRIPTION
Updates the source to point at the repo so `pod install` can find this

(in the meantime, `pod 'LifetimeTracker', :git => "https://github.com/krzysztofzablocki/LifetimeTracker.git", :configurations => ['Debug']` works)