### PR TITLE
Cosmetic change due to API Design Guidelines (naming convention)

### DIFF
--- a/Sources/LifetimeTracker.swift
+++ b/Sources/LifetimeTracker.swift
@@ -15,7 +15,7 @@ public typealias LifetimeConfiguration = (identifier: String, maxCount: Int)
 public protocol LifetimeTrackable: class {
 
     /// Configuration for lifetime tracking, contains identifier and leak classifier
-    static var LifetimeConfiguration: LifetimeConfiguration { get }
+    static var lifetimeConfiguration: LifetimeConfiguration { get }
 
     /// Starts tracking lifetime, should be called in each initializer
     func trackLifetime()


### PR DESCRIPTION
At the moment, LifetimeConfiguration type-alias and main property in LifetimeTrackable protocol have the same names. I think we should avoid this due to Swift naming convention.