### PR TITLE
Add super calls for prepareForReuse

### DIFF
--- a/Sources/DashboardView/DashboardTableViewCell.swift
+++ b/Sources/DashboardView/DashboardTableViewCell.swift
@@ -18,6 +18,7 @@ class DashboardTableViewCell: UITableViewCell {
 	}
 
 	override func prepareForReuse() {
+		super.prepareForReuse()
 		groupIndicatorView.backgroundColor = .clear
 		classIndicatorView.backgroundColor = .clear
 		descriptionLabel.text = nil

--- a/Sources/DashboardView/DashboardTableViewHeaderView.swift
+++ b/Sources/DashboardView/DashboardTableViewHeaderView.swift
@@ -17,6 +17,7 @@ class DashboardTableViewHeaderView: UITableViewHeaderFooterView {
 	}
 	
 	override func prepareForReuse() {
+		super.prepareForReuse()
 		indicatorView.backgroundColor = .clear
 		groupNameLabel.text = nil
 	}


### PR DESCRIPTION
Fixes #35 

- UITableViewCell [docs](https://developer.apple.com/documentation/uikit/uitableviewcell/1623223-prepareforreuse) state that `super.prepareForReuse` must be called. 
- The UITableHeaderFooterView [docs](https://developer.apple.com/documentation/uikit/uitableviewheaderfooterview/1624916-prepareforreuse) make no such mention but it's likely good to add it for convention.
- This file uses tabs vs spaces so when I edited it via Xcode I noticed the diff was very odd looking (as in the alignment was off in Github but not in Xcode). 
  - I had to ensure I was using tabs over spaces, I just wanted to give a heads up to devs who change this in the future and not to start a debate on tabs vs spaces 😛 
- I tested this manually by verifying the views remain unchanged before and after

