### PR TITLE
Add @objc annotations to LifetimeTracker

### DIFF
--- a/Sources/LifetimeTracker.swift
+++ b/Sources/LifetimeTracker.swift
@@ -14,14 +14,14 @@ import Foundation
     /// Maximum count of valid instances
     ///
     /// LifetimeTracker will show a warning if more instance of the class are alive.
-    public var maxCount: Int
+    @objc public var maxCount: Int
     
     /// Name which defines that the instance should be tracked as part of the chosen group.
     ///
     /// A group will automatically be created if there is none with a matching name.
     ///
     /// The usage is optional. The instances will be tracked as standalone items based on their class names if no group is chosen.
-    public var groupName: String? = nil
+    @objc public var groupName: String? = nil
     
     /// Maximum count of valid entries in the whole group.
     ///
@@ -43,7 +43,7 @@ import Foundation
     ///
     /// - Parameters:
     ///   - maxCount: Maximum count of valid instances
-    public init(maxCount: Int) {
+    @objc public init(maxCount: Int) {
         self.maxCount = maxCount
     }
     
@@ -58,7 +58,7 @@ import Foundation
     /// - Parameters:
     ///   - maxCount: Maximum count of valid instances
     ///   - groupName: Name which defines that the instance should be tracked as part of the chosen group. A group will automatically be created if there is none with a matching name.
-    public init(maxCount: Int, groupName: String) {
+    @objc public init(maxCount: Int, groupName: String) {
         self.maxCount = maxCount
         self.groupName = groupName
     }
@@ -75,7 +75,7 @@ import Foundation
     ///   - maxCount: Maximum count of valid instances. LifetimeTracker will show a warning if more instances of the class are alive
     ///   - groupName: Name which defines that the instance should be tracked as part of the chosen group. A group will automatically be created if there is none with a matching name.
     ///   - groupMaxCount: Maximum count of valid entries in the whole group. LifetimeTracker will through a warning if `groupMaxCount` is too high although all members didn't reach their own `maxCount`
-    public init(maxCount: Int, groupName: String, groupMaxCount: Int) {
+    @objc public init(maxCount: Int, groupName: String, groupMaxCount: Int) {
         self.maxCount = maxCount
         self.groupName = groupName
         self.groupMaxCount = groupMaxCount


### PR DESCRIPTION
Fixes #34 

- In order to work with Swift 4, I've added missing `@objc` annotations to the init functions of `LifetimeConfiguration`
- Additionally, I've add the annotations to the properties that could be converted to Objective-C to match the Swift 3 generated interface.

The generated Obj-C interface from Swift 4 originally looked like this:
```objective-c
/// Holds the properties which are needed to configure a <code>LifetimeTrackable</code>
SWIFT_CLASS("_TtC15LifetimeTracker21LifetimeConfiguration")
@interface LifetimeConfiguration : NSObject

@property (nonatomic) NSInteger maxCount SWIFT_DEPRECATED_OBJC("Swift property 'LifetimeConfiguration.maxCount' uses '@objc' inference deprecated in Swift 4; add '@objc' to provide an Objective-C entrypoint");
@property (nonatomic, copy) NSString * _Nullable groupName SWIFT_DEPRECATED_OBJC("Swift property 'LifetimeConfiguration.groupName' uses '@objc' inference deprecated in Swift 4; add '@objc' to provide an Objective-C entrypoint");

- (nonnull instancetype)initWithMaxCount:(NSInteger)maxCount OBJC_DESIGNATED_INITIALIZER SWIFT_DEPRECATED_OBJC("Swift initializer 'LifetimeConfiguration.init(maxCount:)' uses '@objc' inference deprecated in Swift 4; add '@objc' to provide an Objective-C entrypoint");
- (nonnull instancetype)initWithMaxCount:(NSInteger)maxCount groupName:(NSString * _Nonnull)groupName OBJC_DESIGNATED_INITIALIZER SWIFT_DEPRECATED_OBJC("Swift initializer 'LifetimeConfiguration.init(maxCount:groupName:)' uses '@objc' inference deprecated in Swift 4; add '@objc' to provide an Objective-C entrypoint");
- (nonnull instancetype)initWithMaxCount:(NSInteger)maxCount groupName:(NSString * _Nonnull)groupName groupMaxCount:(NSInteger)groupMaxCount OBJC_DESIGNATED_INITIALIZER SWIFT_DEPRECATED_OBJC("Swift initializer 'LifetimeConfiguration.init(maxCount:groupName:groupMaxCount:)' uses '@objc' inference deprecated in Swift 4; add '@objc' to provide an Objective-C entrypoint");
- (nonnull instancetype)init SWIFT_UNAVAILABLE;
@end
``` 

After this PR, it now matches the Swift 3 generated Obj-C interface:
```objective-c
/// Holds the properties which are needed to configure a <code>LifetimeTrackable</code>
SWIFT_CLASS("_TtC15LifetimeTracker21LifetimeConfiguration")
@interface LifetimeConfiguration : NSObject

@property (nonatomic) NSInteger maxCount;
@property (nonatomic, copy) NSString * _Nullable groupName;

- (nonnull instancetype)initWithMaxCount:(NSInteger)maxCount OBJC_DESIGNATED_INITIALIZER;
- (nonnull instancetype)initWithMaxCount:(NSInteger)maxCount groupName:(NSString * _Nonnull)groupName OBJC_DESIGNATED_INITIALIZER;
- (nonnull instancetype)initWithMaxCount:(NSInteger)maxCount groupName:(NSString * _Nonnull)groupName groupMaxCount:(NSInteger)groupMaxCount OBJC_DESIGNATED_INITIALIZER;
- (nonnull instancetype)init SWIFT_UNAVAILABLE;
@end
```