### PR TITLE
Fixed iOS build on Xcode 9.3

### DIFF
--- a/LifetimeTracker.xcodeproj/project.pbxproj
+++ b/LifetimeTracker.xcodeproj/project.pbxproj
@@ -756,7 +756,6 @@
 		52D6D9911BEFF229002C0205 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -779,7 +778,6 @@
 		52D6D9921BEFF229002C0205 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Removed `APPLICATION_EXTENSION_API_ONLY = YES` for iOS.
It builds successfully as all other platforms.

Fixes https://github.com/krzysztofzablocki/LifetimeTracker/issues/42