### PR TITLE
Updated for Xcode 10.2

### DIFF
--- a/LifetimeTracker.xcodeproj/project.pbxproj
+++ b/LifetimeTracker.xcodeproj/project.pbxproj
@@ -449,7 +449,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = LifetimeTracker;
 				TargetAttributes = {
 					52D6D97B1BEFF229002C0205 = {
@@ -484,10 +484,11 @@
 			};
 			buildConfigurationList = 52D6D9761BEFF229002C0205 /* Build configuration list for PBXProject "LifetimeTracker" */;
 			compatibilityVersion = "Xcode 6.3";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 52D6D9721BEFF229002C0205;
 			productRefGroup = 52D6D97D1BEFF229002C0205 /* Products */;
@@ -670,6 +671,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
@@ -727,6 +729,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;

--- a/LifetimeTracker.xcodeproj/xcshareddata/xcschemes/LifetimeTracker-iOS.xcscheme
+++ b/LifetimeTracker.xcodeproj/xcshareddata/xcschemes/LifetimeTracker-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/LifetimeTracker.xcodeproj/xcshareddata/xcschemes/LifetimeTracker-macOS.xcscheme
+++ b/LifetimeTracker.xcodeproj/xcshareddata/xcschemes/LifetimeTracker-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/LifetimeTracker.xcodeproj/xcshareddata/xcschemes/LifetimeTracker-tvOS.xcscheme
+++ b/LifetimeTracker.xcodeproj/xcshareddata/xcschemes/LifetimeTracker-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/LifetimeTracker.xcodeproj/xcshareddata/xcschemes/LifetimeTracker-watchOS.xcscheme
+++ b/LifetimeTracker.xcodeproj/xcshareddata/xcschemes/LifetimeTracker-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
These are the suggested updates for Xcode 10.2. "English" is deprecated and replaces by "en", and we will warn if we add bare localized strings.