### PR TITLE
String(reflecting:) instead of String(describing:) for instanceName

### DIFF
--- a/Sources/LifetimeTracker.swift
+++ b/Sources/LifetimeTracker.swift
@@ -84,7 +84,7 @@ import Foundation
     internal static func makeCompleteConfiguration(with instance: LifetimeTrackable) -> LifetimeConfiguration {
         let instanceType = type(of: instance)
         let configuration = instanceType.lifetimeConfiguration
-        configuration.instanceName = String(describing: instanceType)
+        configuration.instanceName = String(reflecting: instanceType)
         configuration.pointerString = "\(Unmanaged<AnyObject>.passUnretained(instance as AnyObject).toOpaque())"
         return configuration
     }
@@ -222,7 +222,7 @@ public extension LifetimeTrackable {
         
         let instanceType = type(of: instance)
         var configuration = configuration
-        configuration.instanceName = String(describing: instanceType)
+        configuration.instanceName = String(reflecting: instanceType)
         configuration.pointerString = "\(Unmanaged<AnyObject>.passUnretained(instance as AnyObject).toOpaque())"
         
         func update(_ configuration: LifetimeConfiguration, with countDelta: Int) {


### PR DESCRIPTION
Hi!

I founded out that in some cases `String(describing:)` for `instanceName` isn't sufficient. When nested types with the same name are used in the project, then it detects leaks. But it's a false positive because `String(describing:)` ignores the name of the wrapping type.

My suggested solution uses `String(reflecting:)` that prefixes type name with the full path of wrapping types.

False positive with `String(describing:)`:
<img width="394" alt="false positive" src="https://user-images.githubusercontent.com/7204475/63927382-df59af00-ca4d-11e9-9659-251c02b610b0.png">

Fixes with `String(reflecting:)`:
<img width="393" alt="correct names" src="https://user-images.githubusercontent.com/7204475/63927392-e1bc0900-ca4d-11e9-9611-97327716be4c.png">
