### PR TITLE
Add option to log leaks to external sources

### DIFF
--- a/Tests/LifetimeTrackerTests/LifetimeTrackerTests.swift
+++ b/Tests/LifetimeTrackerTests/LifetimeTrackerTests.swift
@@ -144,12 +144,28 @@ class LifetimeTrackerTests: XCTestCase {
         XCTAssertEqual(currentGroupMaxCount, 2, "Overriden group maxCount != 2 after the modifcation of maxCount")
     }
 
+    func testLeakClosure() {
+        var hasLeaked = false
+        LifetimeTracker.instance?.onLeakDetected = { instanceName, count, maxCount in
+            hasLeaked = true
+            print("POSSIBLE LEAK ALERT: \(instanceName) - current count: \(count), max count: \(maxCount)")
+        }
+
+        TrackableObject.lifetimeConfiguration = LifetimeConfiguration(maxCount: 1)
+        var trackables = [TrackableObject]()
+        trackables.append(TrackableObject())
+        XCTAssert(!hasLeaked)
+        trackables.append(TrackableObject())
+        XCTAssert(hasLeaked)
+    }
+
     static var allTests = [
         ("testDeallocTrackerFiresOnDealloc", testDeallocTrackerFiresOnDealloc),
         ("testDeallocTrackerDoesntFire", testDeallocTrackerDoesntFire),
         ("testEntryMaxCountDoesNotChangeAfterMultipleAllocations", testEntryMaxCountDoesNotChangeAfterMultipleAllocations),
         ("testConfigurationMaxCountIncrementationUpdatesEntryAndGroupMaxCount", testConfigurationMaxCountIncrementationUpdatesEntryAndGroupMaxCount),
         ("testConfigurationMaxCountDecrementationUpdatesEntryAndGroupMaxCount", testConfigurationMaxCountDecrementationUpdatesEntryAndGroupMaxCount),
-        ("testConfigurationMaxCountIncrementationDoeNotChangeOverriddenGroupsMaxCount", testConfigurationMaxCountIncrementationDoeNotChangeOverriddenGroupsMaxCount)
+        ("testConfigurationMaxCountIncrementationDoeNotChangeOverriddenGroupsMaxCount", testConfigurationMaxCountIncrementationDoeNotChangeOverriddenGroupsMaxCount),
+        ("testLeakClosure", testLeakClosure)
     ]
 }

--- a/Tests/LifetimeTrackerTests/LifetimeTrackerTests.swift
+++ b/Tests/LifetimeTrackerTests/LifetimeTrackerTests.swift
@@ -146,9 +146,8 @@ class LifetimeTrackerTests: XCTestCase {
 
     func testLeakClosure() {
         var hasLeaked = false
-        LifetimeTracker.instance?.onLeakDetected = { instanceName, count, maxCount in
+        LifetimeTracker.instance?.onLeakDetected = { entry, group in
             hasLeaked = true
-            print("POSSIBLE LEAK ALERT: \(instanceName) - current count: \(count), max count: \(maxCount)")
         }
 
         TrackableObject.lifetimeConfiguration = LifetimeConfiguration(maxCount: 1)


### PR DESCRIPTION
## Introduction

This proposal provides an opportunity to improve the existing surfacing mechanism of a retain cycle/memory issues to external sources, such as firebase analytics, datadog logging services, etc.

## Motivation

Having UI indication of leaks/memory issues is not always sufficient, especially in production environments, expanding integration with an ability to log those issues can provide the ability to analyze incoming memory issues.  

## Proposed solution

The introduction of closure such as `onLeakDetected` can provide desired functionality without interfering with original designs. We can retrieve desired parameters such as `instanceName` | `entry  count` | `entry  desiredCount` to provide information about those leaks to external sources.

So the final callback would look like the following code:

```swift
LifetimeTracker.instance?.onLeakDetected = { instanceName, count, maxCount in
    print("POSSIBLE LEAK ALERT: \(instanceName) - current count: \(count), max count: \(maxCount)")
}
```

cc original author: @ericzelermyer