### PR TITLE
Fix resources path & bundle for CocoaPods

### DIFF
--- a/LifetimeTracker.podspec
+++ b/LifetimeTracker.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/krzysztofzablocki/LifetimeTracker.git", :tag => s.version.to_s }
   s.ios.source_files  = "Sources/*.swift", "Sources/iOS/**/*.swift"
   s.macos.source_files  = "Sources/*.swift"
-  s.ios.resources     = "Sources/iOS/**/*.{xib,storyboard}"
+  s.ios.resources     = "Sources/Resources/**/*.{xib,storyboard}"
   s.resource_bundle = { "LifetimeTracker" => ["Sources/**/*.{strings}"] }
   s.ios.frameworks  = ["Foundation", "UIKit"]
   s.macos.frameworks  = ["Foundation"]

--- a/Sources/Bundle+Extensions.swift
+++ b/Sources/Bundle+Extensions.swift
@@ -14,7 +14,7 @@ extension Bundle {
         #if SWIFT_PACKAGE
         return Bundle.module
         #else
-        return Bundle(for: self)
+        return Bundle(for: LifetimeTracker.self)
         #endif
     }
 }


### PR DESCRIPTION
Looks like the path of the resource files changed in the latest release - updated the podspec to reflect that.