### PR TITLE
Fix localization to use the correct bundle

### DIFF
--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -11,10 +11,6 @@ import Foundation
 internal extension String {
 
     var lt_localized: String {
-        let bundle = Bundle(for: LifetimeTracker.self)
-        let resourceBundle = bundle
-            .path(forResource: "LifetimeTracker", ofType: "bundle")
-            .map { Bundle(path: $0) ?? bundle } ?? bundle
-        return NSLocalizedString(self, bundle: resourceBundle, comment: self)
+        Bundle.resolvedBundle.localizedString(forKey: self, value: self, table: nil)
     }
 }


### PR DESCRIPTION
The bundle used for localization should be `module` for packages

<img width="349" alt="image" src="https://user-images.githubusercontent.com/7687808/165112941-8afd8bca-dfdd-4b5b-a75e-9283cd1abdc5.png">

<img width="344" alt="image" src="https://user-images.githubusercontent.com/7687808/165112987-3d735e05-5dd6-46ec-bb32-dea8b93e757c.png">
