### PR TITLE
Make track function public in LifetimeTracker class

### DIFF
--- a/Sources/LifetimeTracker.swift
+++ b/Sources/LifetimeTracker.swift
@@ -229,7 +229,7 @@ public extension LifetimeTrackable {
         self.onLeakDetected = onLeakDetected
     }
     
-    internal func track(_ instance: Any, configuration: LifetimeConfiguration, file: String = #file) {
+    public func track(_ instance: Any, configuration: LifetimeConfiguration, file: String = #file) {
         lock.lock()
         defer {
             onUpdate(trackedGroups)


### PR DESCRIPTION
## Issue
A proxy is needed for a project that only links LifetimeTracker for a certain build. The following example explains the usage, that it can't use LifetimeTracker directly. The project only wants LifetimeTracker links to QA build.

**Codebase**

```
class A {} // linked to Production & QA targets
class B {} // linked to Production & QA targets
```

## Solution
In order to achieve the goal, a custom LifetimeTrackerProxy class wraps the `LifetimeTracker`, and only used in QA build. So in this case the track function need to be public.

```
#if QA
import LifetimeTracker
#endif

class LifetimeTrackerProxy {
// singleton implementation ...

#if QA
    func customTrack(....) {
        LifetimeTracker.instance?.track(_ instance, configuration: configuration)
    }
#else
    func customTrack(....) {
        // do nothing
    }
#endif
}
```

## Discussion
I understand using `internal` can help to prevent misuse, and make framework easier to maintain. But the change can make the framework more flexible for client to integrate in a larger project with variety build flavors.