### PR TITLE
Fix leak detection and warning

### DIFF
--- a/Sources/DeallocTracker.swift
+++ b/Sources/DeallocTracker.swift
@@ -26,9 +26,11 @@ fileprivate final class DeallocTracker {
 ///   - owner: Owner to track.
 ///   - closure: Closure to execute.
 internal func onDealloc(of owner: Any, closure: @escaping () -> Void) {
-    var tracker = DeallocTracker(onDealloc: closure)
-    withUnsafePointer(to: tracker) { pointer in
-        var tracker = pointer
-        objc_setAssociatedObject(owner, &tracker, tracker, .OBJC_ASSOCIATION_RETAIN)
-    }
+    let tracker = DeallocTracker(onDealloc: closure)
+    objc_setAssociatedObject(owner, getID(tracker), tracker, .OBJC_ASSOCIATION_RETAIN)
+}
+
+// https://github.com/atrick/swift-evolution/blob/diagnose-implicit-raw-bitwise/proposals/nnnn-implicit-raw-bitwise-conversion.md#associated-object-string-keys
+private func getID(_ object: AnyObject) -> UnsafeRawPointer {
+    return UnsafeRawPointer(Unmanaged.passUnretained(object).toOpaque())
 }


### PR DESCRIPTION
Revert f5c25c5bb152892df9b333b16c6b74fe7060ab55 which introduced regression (`testDeallocTrackerDoesntFire` failure).

Then fix original warning:

>Forming 'UnsafeRawPointer' to a variable of type 'DeallocTracker';
this is likely incorrect because 'DeallocTracker' may contain an object reference.

by workaround from swift evolution proposal: https://github.com/atrick/swift-evolution/blob/diagnose-implicit-raw-bitwise/proposals/nnnn-implicit-raw-bitwise-conversion.md#associated-object-string-keys

Resolves https://github.com/krzysztofzablocki/LifetimeTracker/issues/93

Before:
<img width="1053" alt="Screenshot 2024-05-30 at 22 38 35" src="https://github.com/krzysztofzablocki/LifetimeTracker/assets/1800899/7b0942c0-12a2-43da-bc6f-f16787d1e951">

After:
<img width="459" alt="image" src="https://github.com/krzysztofzablocki/LifetimeTracker/assets/1800899/a162a67f-51a0-4687-bd70-c48061e254f7">
