### PR TITLE
[ISSUE-98]  Fix for Lifetime tracker blocks UI when closed

### DIFF
--- a/Sources/iOS/UI/BarDashboard/BarDashboardViewController.swift
+++ b/Sources/iOS/UI/BarDashboard/BarDashboardViewController.swift
@@ -60,7 +60,7 @@ final class BarDashboardViewController: UIViewController, LifetimeTrackerViewabl
     private var hideOption: HideOption = .none {
         didSet {
             if hideOption != .none {
-                view.isHidden = true
+                view.window?.isHidden = true
             }
         }
     }

--- a/Sources/iOS/UI/CircularDashboard/CircularDashboardViewController.swift
+++ b/Sources/iOS/UI/CircularDashboard/CircularDashboardViewController.swift
@@ -36,7 +36,7 @@ class CircularDashboardViewController: UIViewController, LifetimeTrackerViewable
     private var hideOption: HideOption = .none {
         didSet {
             if hideOption != .none {
-                view.isHidden = true
+                view.window?.isHidden = true
             }
         }
     }


### PR DESCRIPTION
Essentially a fix for #98 to hide whole overlay window whenever user dismisses LifetimeTracker from settings.
This ensures LiftetimeTracker UI when hidden, does not obstruct the application interactions.


https://github.com/user-attachments/assets/abf6816d-8c79-4d08-85db-fb0490952059

