### PR TITLE
Fix circle reappearing after user dismissal

### DIFF
--- a/Sources/iOS/UI/BarDashboard/BarDashboardViewController.swift
+++ b/Sources/iOS/UI/BarDashboard/BarDashboardViewController.swift
@@ -57,6 +57,8 @@ final class BarDashboardViewController: UIViewController, LifetimeTrackerViewabl
         didSet { clampDragOffset() }
     }
 
+    var isHiddenByUser: Bool { return hideOption != .none }
+
     private var hideOption: HideOption = .none {
         didSet {
             if hideOption != .none {
@@ -100,8 +102,8 @@ final class BarDashboardViewController: UIViewController, LifetimeTrackerViewabl
         summaryLabel?.attributedText = vm.summary
 
         if hideOption.shouldUIBeShown(oldModel: dashboardViewModel, newModel: vm) {
-            view.isHidden = false
             hideOption = .none
+            view.window?.isHidden = false
         }
 
         dashboardViewModel = vm

--- a/Sources/iOS/UI/CircularDashboard/CircularDashboardViewController.swift
+++ b/Sources/iOS/UI/CircularDashboard/CircularDashboardViewController.swift
@@ -17,6 +17,8 @@ protocol LifetimeTrackerViewable {
 
     static func makeFromNib() -> UIViewController & LifetimeTrackerViewable
 
+    var isHiddenByUser: Bool { get }
+
     func update(with vm: BarDashboardViewModel)
 }
 
@@ -32,6 +34,8 @@ class CircularDashboardViewController: UIViewController, LifetimeTrackerViewable
     fileprivate var formerStatusBarStyle = UIApplication.shared.statusBarStyle
 
     private var didInitializeRoundView = false
+
+    var isHiddenByUser: Bool { return hideOption != .none }
 
     private var hideOption: HideOption = .none {
         didSet {
@@ -141,8 +145,8 @@ class CircularDashboardViewController: UIViewController, LifetimeTrackerViewable
         leaksTitleLabel?.text = vm.leaksCount == 1 ? "word.leak".lt_localized : "word.leaks".lt_localized
 
         if hideOption.shouldUIBeShown(oldModel: dashboardViewModel, newModel: vm) {
-            view.isHidden = false
             hideOption = .none
+            view.window?.isHidden = false
         }
 
         dashboardViewModel = vm

--- a/Sources/iOS/UI/LifetimeTracker+DashboardView.swift
+++ b/Sources/iOS/UI/LifetimeTracker+DashboardView.swift
@@ -102,7 +102,9 @@ typealias GroupModel = (color: UIColor, title: String, groupName: String, groupC
 
     @objc public func refreshUI(trackedGroups: [String: LifetimeTracker.EntriesGroup]) {
         DispatchQueue.main.async {
-            self.window.isHidden = self.visibility.windowIsHidden(hasIssuesToDisplay: self.hasIssuesToDisplay(from: trackedGroups))
+            if !self.lifetimeTrackerView.isHiddenByUser {
+                self.window.isHidden = self.visibility.windowIsHidden(hasIssuesToDisplay: self.hasIssuesToDisplay(from: trackedGroups))
+            }
 
             let entries = self.entries(from: trackedGroups)
             let vm = BarDashboardViewModel(


### PR DESCRIPTION
## Summary

- `refreshUI()` was unconditionally setting `window.isHidden` on every update cycle, overriding the user's dismissal preference (hide until more issues / new issue type / restart). Now it checks `isHiddenByUser` before toggling window visibility.
- Fixed reappearance logic in `update(with:)` to unhide the **window** (`view.window?.isHidden = false`) instead of the **view** (`view.isHidden = false`), matching the PR #99 change that switched dismissal from hiding the view to hiding the window.


https://github.com/user-attachments/assets/35de1a1b-3d35-4367-80b9-f70197142e13


🤖 Generated with [Claude Code](https://claude.com/claude-code)